### PR TITLE
ChangeLogEntry resolved authers to non-existing users

### DIFF
--- a/src/main/java/hudson/plugins/synergy/SynergyChangeLogSet.java
+++ b/src/main/java/hudson/plugins/synergy/SynergyChangeLogSet.java
@@ -143,7 +143,7 @@ public final class SynergyChangeLogSet extends ChangeLogSet<SynergyChangeLogSet.
 
 		@Exported
 		public String getUser() {
-			return author==null ? null : author.getDisplayName();
+			return author==null ? null : author.getId();
 		}
 
 		@Exported


### PR DESCRIPTION
ChangeLogEntry resolved authers to non-existing users (named by their display name, e.g. "Stefan Schulze" instead of "sschulze")
