### PR TITLE
It looks like Synergy uses ISO-8859-1 for stdout-output

### DIFF
--- a/src/main/java/hudson/plugins/synergy/impl/Commands.java
+++ b/src/main/java/hudson/plugins/synergy/impl/Commands.java
@@ -173,7 +173,7 @@ public class Commands implements Serializable {
 			printCommandLine(commands, null, mask);
 		}
 		int result = launcher.launch().cmds(commands).masks(mask).envs(env).stdout(out).pwd(path).join();
-		String output = out.toString();
+		String output = out.toString("ISO-8859-1");
 		
 		if (!command.isStatusOK(result, output)) {
 			buildListener.getLogger().println("ccm command failed");


### PR DESCRIPTION
It looks like Synergy uses ISO-8859-1 for stdout-output, but it is read with the current system-encoding. If your server uses UTF-8 and the a task-synopsis contains special characters (like german umlauts) you get illegal characters in the synopsis and changelog.
I fixed it by explicitly setting the encoding in Commands.java.

If anybody knows, that this is configured somewhere within Synergy, please tell me, so I'll make it configurable.
