### PR TITLE
Fix issue when checking for conflicts in Synergy 7.1

### DIFF
--- a/src/main/java/hudson/plugins/synergy/impl/ProjectConflicts.java
+++ b/src/main/java/hudson/plugins/synergy/impl/ProjectConflicts.java
@@ -33,7 +33,12 @@ public class ProjectConflicts extends Command {
 				line = line.trim();
 				if((line.indexOf("Conflict detection completed") == -1) &&
 					(line.indexOf("Finding objects that are not included") == -1) &&
-					(line.indexOf("Collecting objects and tasks beyond baseline") == -1))
+					(line.indexOf("Collecting objects and tasks beyond baseline") == -1) &&
+					  // the following lines are needed using Synergy 7.1; these lines occure sporadically!
+					(line.indexOf("%...") == -1) &&	 // lines like "0%..."
+					(line.indexOf("Getting explicitly included objects.") == -1) &&
+					(line.indexOf("Getting members of baseline project.") == -1) &&
+					(line.indexOf("Checking for missing fix tasks.") == -1))
 				{
 					if (line.length()!=0 && !line.startsWith("Project:") && line.indexOf("No conflicts detected")==-1) {				
 						


### PR DESCRIPTION
The lines, which I added occure sporadically with Synergy 7.1. If they are not checked the plugin would consider them as update conflicts and assumes that the update of the Synergy workarea has failed.
